### PR TITLE
Kurs in Projekt umbenannt

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ After that you direct your terminal to the directory of the shadow jar (it's in 
 
 To add an entry to your tracked events, use
 
-`java -jar SHADOW_JAR_FILE_NAME.jar -a <YYYY-MM-DD>,<minutes>,<course>,"<description>"`
+`java -jar SHADOW_JAR_FILE_NAME.jar -a <YYYY-MM-DD>,<minutes>,<project>,"<description>"`
  
 To sum all the time spent with those events and print it to the console, use
 

--- a/src/main/java/de/propra/timetracker/Event.java
+++ b/src/main/java/de/propra/timetracker/Event.java
@@ -4,17 +4,17 @@ import org.apache.commons.csv.CSVRecord;
 
 import java.util.List;
 
-record Event(String datum, int minuten, String kurs, String beschreibung) {
+record Event(String datum, int minuten, String projekt, String beschreibung) {
     Event(CSVRecord record) {
         this(
                 record.get(Spalten.DATUM),
                 Integer.parseInt(record.get(Spalten.MINUTEN)),
-                record.get(Spalten.KURS),
+                record.get(Spalten.PROJEKT),
                 record.get(Spalten.BESCHREIBUNG)
         );
     }
 
     public List<String> asList() {
-        return List.of(this.datum, String.valueOf(this.minuten), this.kurs, this.beschreibung);
+        return List.of(this.datum, String.valueOf(this.minuten), this.projekt, this.beschreibung);
     }
 }

--- a/src/main/java/de/propra/timetracker/Spalten.java
+++ b/src/main/java/de/propra/timetracker/Spalten.java
@@ -3,13 +3,13 @@ package de.propra.timetracker;
 import java.util.List;
 
 enum Spalten {
-    DATUM, MINUTEN, KURS, BESCHREIBUNG;
+    DATUM, MINUTEN, PROJEKT, BESCHREIBUNG;
 
     public static List<String> asList() {
         return List.of(
                 Spalten.DATUM.toString(),
                 Spalten.MINUTEN.toString(),
-                Spalten.KURS.toString(),
+                Spalten.PROJEKT.toString(),
                 Spalten.BESCHREIBUNG.toString()
         );
     }


### PR DESCRIPTION
Benennt im Code jeweils `Kurs` in `Projekt` um und passt die README entsprechend an (Issue #8 )