### PR TITLE
Convert tabs to spaces and add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+
+[*.java]
+indent_style = space
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ end_of_line = lf
 [*.java]
 indent_style = space
 insert_final_newline = true
+
+[*.xml]
+indent_size = 2

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -16,5 +16,10 @@
       <option name="name" value="MavenRepo" />
       <option name="url" value="https://repo.maven.apache.org/maven2/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://jitpack.io" />
+    </remote-repository>
   </component>
 </project>

--- a/src/main/java/de/propra/timetracker/TablePrinter.java
+++ b/src/main/java/de/propra/timetracker/TablePrinter.java
@@ -1,16 +1,17 @@
 package de.propra.timetracker;
 
 import net.steppschuh.markdowngenerator.table.Table;
-import java.util.List;
 
+import java.util.List;
+ 
 public class TablePrinter {
 
-	static void printTable(List<Event> events) {
-		Table.Builder tableBuilder = new Table.Builder()
-				.withAlignments(Table.ALIGN_LEFT, Table.ALIGN_LEFT, Table.ALIGN_LEFT, Table.ALIGN_LEFT)
-				.addRow("Datum", "Minuten", "Projekt", "Beschreibung");
+    static void printTable(List<Event> events) {
+        Table.Builder tableBuilder = new Table.Builder()
+                .withAlignments(Table.ALIGN_LEFT, Table.ALIGN_LEFT, Table.ALIGN_LEFT, Table.ALIGN_LEFT)
+                .addRow("Datum", "Minuten", "Projekt", "Beschreibung");
 
-		events.forEach(e -> tableBuilder.addRow(e.datum(),e.minuten(),e.projekt(),e.beschreibung()));
-		System.out.println(tableBuilder.build());
-	}
+        events.forEach(e -> tableBuilder.addRow(e.datum(), e.minuten(), e.projekt(), e.beschreibung()));
+        System.out.println(tableBuilder.build());
+    }
 }

--- a/src/main/java/de/propra/timetracker/TimeTrackerCLI.java
+++ b/src/main/java/de/propra/timetracker/TimeTrackerCLI.java
@@ -50,10 +50,10 @@ public class TimeTrackerCLI {
                 Event event = new Event(optionValues[0], Integer.parseInt(optionValues[1]), optionValues[2], optionValues[3]);
                 csv.appendRow(event.asList());
                 return CLIStatus.ADD_ENTRY;
-			} else if (cmd.hasOption("t")) {
-				TablePrinter.printTable(csv.readCSV());
-				return CLIStatus.SHOW_TABLE;
-			}
+            } else if (cmd.hasOption("t")) {
+                TablePrinter.printTable(csv.readCSV());
+                return CLIStatus.SHOW_TABLE;
+            }
         } catch (ParseException e) {
             hilfe();
             return CLIStatus.ERROR;


### PR DESCRIPTION
Konvertiert alle Tabs zu spaces. Mit der .editorconfig gibt es nun auch einen gemeinsamen Stil, der über Editorgrenzen hinweg gilt. 