### PR TITLE
--add today als Alternative zu --add YYYY-MM-DD

### DIFF
--- a/.idea/git_toolbox_prj.xml
+++ b/.idea/git_toolbox_prj.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxProjectSettings">
+    <option name="commitMessageIssueKeyValidationOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+    <option name="commitMessageValidationEnabledOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ After that you direct your terminal to the directory of the shadow jar (it's in 
 
 To add an entry to your tracked events, use
 
-`java -jar SHADOW_JAR_FILE_NAME.jar -a <YYYY-MM-DD>,<minutes>,<project>,"<description>"`
+`java -jar SHADOW_JAR_FILE_NAME.jar -a <YYYY-MM-DD*>,<minutes>,<project>,"<description>"`
+
+_*(or use "today" instead of "YYYY-MM-DD" to use current date)_
  
 To sum all the time spent with those events and print it to the console, use
 

--- a/src/main/java/de/propra/timetracker/TimeTrackerCLI.java
+++ b/src/main/java/de/propra/timetracker/TimeTrackerCLI.java
@@ -66,7 +66,8 @@ public class TimeTrackerCLI {
                 return CLIStatus.SUM_MINUTES;
             } else if (cmd.hasOption("a")) {
                 String[] optionValues = cmd.getOptionValues("a");
-                Event event = new Event(optionValues[0], Integer.parseInt(optionValues[1]), optionValues[2], optionValues[3]);
+                String date = optionValues[0].equals("today") ? java.time.LocalDate.now().toString() : optionValues[0];
+                Event event = new Event(date, Integer.parseInt(optionValues[1]), optionValues[2], optionValues[3]);
                 csv.appendRow(event.asList());
                 return CLIStatus.ADD_ENTRY;
             } else if (cmd.hasOption("t")) {

--- a/src/test/java/de/propra/timetracker/TimeTrackerCLITest.java
+++ b/src/test/java/de/propra/timetracker/TimeTrackerCLITest.java
@@ -43,21 +43,21 @@ class TimeTrackerCLITest {
 
     @Test
     @DisplayName("--sum-of-project summiert alle Einträge eines bestimmten events und gibt sie aus.")
-    void readCLI6() throws IOException {
+    void readCLI4() throws IOException {
         CLIStatus cliStatus = timeTrackerCLI.readCLI(new String[]{"--sum-of-project", "projektname"});
         assertThat(cliStatus).isEqualTo(CLIStatus.SUM_MINUTES);
     }
 
     @Test
     @DisplayName("--sum-of-date summiert alle Einträge eines bestimmten events und gibt sie aus.")
-    void readCLI9() throws IOException {
+    void readCLI5() throws IOException {
         CLIStatus cliStatus = timeTrackerCLI.readCLI(new String[]{"--sum-of-date", "2022-05-10"});
         assertThat(cliStatus).isEqualTo(CLIStatus.SUM_MINUTES);
     }
 
     @Test
     @DisplayName("--add fügt neuen Eintrag hinzu.")
-    void readCLI4() throws IOException {
+    void readCLI6() throws IOException {
         String[] arguments = {
                 "--add",
                 "2022-05-11,90,ProPra1,\"Stream #4\""
@@ -68,21 +68,21 @@ class TimeTrackerCLITest {
 
     @Test
     @DisplayName("--table gibt alle Einträge in einer Tabelle aus.")
-    void readCLI5() throws IOException {
+    void readCLI7() throws IOException {
         CLIStatus cliStatus = timeTrackerCLI.readCLI(new String[]{"--table"});
         assertThat(cliStatus).isEqualTo(CLIStatus.SHOW_TABLE);
     }
 
     @Test
     @DisplayName("--table-of-project gibt alle Einträge eines Projekts in einer Tabelle aus.")
-    void readCLI7() throws IOException {
+    void readCLI8() throws IOException {
         CLIStatus cliStatus = timeTrackerCLI.readCLI(new String[]{"--table-of-project", "projektname"});
         assertThat(cliStatus).isEqualTo(CLIStatus.SHOW_TABLE);
     }
 
     @Test
     @DisplayName("--table-of-date gibt alle Einträge eines Datums in einer Tabelle aus.")
-    void readCLI8() throws IOException {
+    void readCLI9() throws IOException {
         CLIStatus cliStatus = timeTrackerCLI.readCLI(new String[]{"--table-of-date", "2022-05-10"});
         assertThat(cliStatus).isEqualTo(CLIStatus.SHOW_TABLE);
     }

--- a/src/test/java/de/propra/timetracker/TimeTrackerCLITest.java
+++ b/src/test/java/de/propra/timetracker/TimeTrackerCLITest.java
@@ -86,4 +86,15 @@ class TimeTrackerCLITest {
         CLIStatus cliStatus = timeTrackerCLI.readCLI(new String[]{"--table-of-date", "2022-05-10"});
         assertThat(cliStatus).isEqualTo(CLIStatus.SHOW_TABLE);
     }
+
+    @Test
+    @DisplayName("--add today fügt neuen Eintrag hinzu.")
+    void readCLI10() throws IOException {
+        String[] arguments = {
+                "--add",
+                "today,90,ProPra1,\"Stream #4\""
+        };
+        CLIStatus cliStatus = timeTrackerCLI.readCLI(arguments);
+        assertThat(cliStatus).isEqualTo(CLIStatus.ADD_ENTRY);
+    }
 }


### PR DESCRIPTION
Man kann nun --add today benutzen, um ein Event am 25.05.2022 hinzuzufügen, anstatt --add 2022-05-25 schreiben zu müssen. Beinhaltet auch eine Build Configuration zum Ausprobieren.

Vorheriger Pull Request hatte Konflikte wegen des zuvor akzeptierten PRs :D

Außerdem hab ich die Tests umbenannt, weil die Reihenfolge bei der Benennung nicht ganz gepasst hat