### PR TITLE
Validiere das Datum des Inputs bei --add

### DIFF
--- a/.idea/modules/time-tracker.main.iml
+++ b/.idea/modules/time-tracker.main.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="CheckStyle-IDEA-Module">
-    <option name="configuration">
-      <map />
-    </option>
-  </component>
-</module>

--- a/src/main/java/de/propra/timetracker/Calculations.java
+++ b/src/main/java/de/propra/timetracker/Calculations.java
@@ -6,6 +6,8 @@ import java.util.Date;
 import java.util.List;
 
 public class Calculations {
+    static SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+
     static int sumMinutes(List<Event> events) {
         return events.stream()
                 .mapToInt(Event::minuten)
@@ -20,12 +22,11 @@ public class Calculations {
     }
 
     static int sumMinutesOfDate(List<Event> events, String datum) {
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         Date date;
         String dateString;
         try {
-            date = format.parse(datum);
-            dateString = format.format(date);
+            date = formatter.parse(datum);
+            dateString = formatter.format(date);
         } catch (ParseException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/de/propra/timetracker/Calculations.java
+++ b/src/main/java/de/propra/timetracker/Calculations.java
@@ -1,10 +1,8 @@
 package de.propra.timetracker;
 
-import java.text.SimpleDateFormat;
 import java.util.List;
 
 public class Calculations {
-    static SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
 
     static int sumMinutes(List<Event> events) {
         return events.stream()

--- a/src/main/java/de/propra/timetracker/Calculations.java
+++ b/src/main/java/de/propra/timetracker/Calculations.java
@@ -35,4 +35,13 @@ public class Calculations {
                 .mapToInt(Event::minuten)
                 .sum();
     }
+
+    static boolean isValidDate(String datum) {
+        try {
+            formatter.parse(datum);
+            return true;
+        } catch (java.text.ParseException e) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/de/propra/timetracker/Calculations.java
+++ b/src/main/java/de/propra/timetracker/Calculations.java
@@ -22,16 +22,8 @@ public class Calculations {
     }
 
     static int sumMinutesOfDate(List<Event> events, String datum) {
-        Date date;
-        String dateString;
-        try {
-            date = formatter.parse(datum);
-            dateString = formatter.format(date);
-        } catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
         return events.stream()
-                .filter(e -> e.datum().equals(dateString))
+                .filter(e -> e.datum().equals(datum))
                 .mapToInt(Event::minuten)
                 .sum();
     }

--- a/src/main/java/de/propra/timetracker/Calculations.java
+++ b/src/main/java/de/propra/timetracker/Calculations.java
@@ -1,8 +1,6 @@
 package de.propra.timetracker;
 
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.List;
 
 public class Calculations {
@@ -28,12 +26,4 @@ public class Calculations {
                 .sum();
     }
 
-    static boolean isValidDate(String datum) {
-        try {
-            formatter.parse(datum);
-            return true;
-        } catch (java.text.ParseException e) {
-            return false;
-        }
-    }
 }

--- a/src/main/java/de/propra/timetracker/CheckDate.java
+++ b/src/main/java/de/propra/timetracker/CheckDate.java
@@ -1,11 +1,14 @@
 package de.propra.timetracker;
 
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 
 public class CheckDate {
+    static SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+
     static boolean isValidDate(String datum) {
         try {
-            Calculations.formatter.parse(datum);
+            formatter.parse(datum);
             return true;
         } catch (ParseException e) {
             return false;

--- a/src/main/java/de/propra/timetracker/CheckDate.java
+++ b/src/main/java/de/propra/timetracker/CheckDate.java
@@ -1,0 +1,14 @@
+package de.propra.timetracker;
+
+import java.text.ParseException;
+
+public class CheckDate {
+    static boolean isValidDate(String datum) {
+        try {
+            Calculations.formatter.parse(datum);
+            return true;
+        } catch (ParseException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/de/propra/timetracker/TablePrinter.java
+++ b/src/main/java/de/propra/timetracker/TablePrinter.java
@@ -2,9 +2,6 @@ package de.propra.timetracker;
 
 import net.steppschuh.markdowngenerator.table.Table;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.List;
 
 public class TablePrinter {
@@ -25,19 +22,10 @@ public class TablePrinter {
     }
 
     static void printTableOfDate(List<Event> events, String datum) {
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
-        Date date;
-        String dateString;
-        try {
-            date = format.parse(datum);
-            dateString = format.format(date);
-        } catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
-        events.stream().filter(d -> d.projekt().equals(dateString))
+        events.stream().filter(d -> d.datum().equals(datum))
                 .forEach(d -> tableBuilder
                         .addRow(d.datum(),d.minuten(),d.projekt(),d.beschreibung()));
         System.out.println(tableBuilder.build());
     }
-}
 
+}

--- a/src/main/java/de/propra/timetracker/TimeTrackerCLI.java
+++ b/src/main/java/de/propra/timetracker/TimeTrackerCLI.java
@@ -4,6 +4,7 @@ import org.apache.commons.cli.*;
 
 import java.io.IOException;
 
+
 enum CLIStatus {
     HELP, SUM_MINUTES, ADD_ENTRY, ERROR, SHOW_TABLE
 }
@@ -61,13 +62,21 @@ public class TimeTrackerCLI {
                 return CLIStatus.SUM_MINUTES;
             } else if (cmd.hasOption("sum-of-date")) {
                 String datum = cmd.getOptionValue("sum-of-date");
+                if(!Calculations.isValidDate(datum)) {
+                    System.out.println("Ungültiges Datum");
+                    return CLIStatus.ERROR;
+                }
                 int minutes = Calculations.sumMinutesOfDate(csv.readCSV(), datum);
                 System.out.printf("Summe: %d Minuten am %s", minutes, datum);
                 return CLIStatus.SUM_MINUTES;
             } else if (cmd.hasOption("a")) {
                 String[] optionValues = cmd.getOptionValues("a");
-                String date = optionValues[0].equals("today") ? java.time.LocalDate.now().toString() : optionValues[0];
-                Event event = new Event(date, Integer.parseInt(optionValues[1]), optionValues[2], optionValues[3]);
+                String datum = optionValues[0].equals("today") ? java.time.LocalDate.now().toString() : optionValues[0];
+                if(!Calculations.isValidDate(datum)) {
+                    System.out.println("Ungültiges Datum");
+                    return CLIStatus.ERROR;
+                }
+                Event event = new Event(datum, Integer.parseInt(optionValues[1]), optionValues[2], optionValues[3]);
                 csv.appendRow(event.asList());
                 return CLIStatus.ADD_ENTRY;
             } else if (cmd.hasOption("t")) {
@@ -79,6 +88,10 @@ public class TimeTrackerCLI {
                 return CLIStatus.SHOW_TABLE;
             } else if (cmd.hasOption("table-of-date")) {
                 String datum = cmd.getOptionValue("table-of-date");
+                if(!Calculations.isValidDate(datum)) {
+                    System.out.println("Ungültiges Datum");
+                    return CLIStatus.ERROR;
+                }
                 TablePrinter.printTableOfDate(csv.readCSV(),datum);
                 return CLIStatus.SHOW_TABLE;
             }

--- a/src/main/java/de/propra/timetracker/TimeTrackerCLI.java
+++ b/src/main/java/de/propra/timetracker/TimeTrackerCLI.java
@@ -4,6 +4,8 @@ import org.apache.commons.cli.*;
 
 import java.io.IOException;
 
+import static de.propra.timetracker.CheckDate.*;
+
 
 enum CLIStatus {
     HELP, SUM_MINUTES, ADD_ENTRY, ERROR, SHOW_TABLE
@@ -62,7 +64,7 @@ public class TimeTrackerCLI {
                 return CLIStatus.SUM_MINUTES;
             } else if (cmd.hasOption("sum-of-date")) {
                 String datum = cmd.getOptionValue("sum-of-date");
-                if(!Calculations.isValidDate(datum)) {
+                if(!isValidDate(datum)) {
                     System.out.println("Ungültiges Datum");
                     return CLIStatus.ERROR;
                 }
@@ -72,7 +74,7 @@ public class TimeTrackerCLI {
             } else if (cmd.hasOption("a")) {
                 String[] optionValues = cmd.getOptionValues("a");
                 String datum = optionValues[0].equals("today") ? java.time.LocalDate.now().toString() : optionValues[0];
-                if(!Calculations.isValidDate(datum)) {
+                if(!isValidDate(datum)) {
                     System.out.println("Ungültiges Datum");
                     return CLIStatus.ERROR;
                 }
@@ -88,7 +90,7 @@ public class TimeTrackerCLI {
                 return CLIStatus.SHOW_TABLE;
             } else if (cmd.hasOption("table-of-date")) {
                 String datum = cmd.getOptionValue("table-of-date");
-                if(!Calculations.isValidDate(datum)) {
+                if(!isValidDate(datum)) {
                     System.out.println("Ungültiges Datum");
                     return CLIStatus.ERROR;
                 }

--- a/src/test/java/de/propra/timetracker/CalculationsTest.java
+++ b/src/test/java/de/propra/timetracker/CalculationsTest.java
@@ -53,14 +53,14 @@ class CalculationsTest {
     @Test
     @DisplayName("2022-05-02 is a valid date")
     void test6() {
-        boolean valid = Calculations.isValidDate("2022-05-02");
+        boolean valid = CheckDate.isValidDate("2022-05-02");
         assertThat(valid).isTrue();
     }
 
     @Test
     @DisplayName("02.05.2022 is not a valid date")
     void test7() {
-        boolean valid = Calculations.isValidDate("02.05.2022");
+        boolean valid = CheckDate.isValidDate("02.05.2022");
         assertThat(valid).isFalse();
     }
 }

--- a/src/test/java/de/propra/timetracker/CalculationsTest.java
+++ b/src/test/java/de/propra/timetracker/CalculationsTest.java
@@ -49,4 +49,18 @@ class CalculationsTest {
         List<Event> events = List.of(event1, event2);
         assertThat(sumMinutesOfDate(events, "2022-05-10")).isEqualTo(60);
     }
+
+    @Test
+    @DisplayName("2022-05-02 is a valid date")
+    void test6() {
+        boolean valid = Calculations.isValidDate("2022-05-02");
+        assertThat(valid).isTrue();
+    }
+
+    @Test
+    @DisplayName("02.05.2022 is not a valid date")
+    void test7() {
+        boolean valid = Calculations.isValidDate("02.05.2022");
+        assertThat(valid).isFalse();
+    }
 }

--- a/src/test/java/de/propra/timetracker/TimeTrackerCLITest.java
+++ b/src/test/java/de/propra/timetracker/TimeTrackerCLITest.java
@@ -97,4 +97,29 @@ class TimeTrackerCLITest {
         CLIStatus cliStatus = timeTrackerCLI.readCLI(arguments);
         assertThat(cliStatus).isEqualTo(CLIStatus.ADD_ENTRY);
     }
+
+    @Test
+    @DisplayName("--table-of-date 22.02.2022 gibt ERROR zurück")
+    void readCLI11() throws IOException {
+        CLIStatus cliStatus = timeTrackerCLI.readCLI(new String[]{"--table-of-date", "22.02.2022"});
+        assertThat(cliStatus).isEqualTo(CLIStatus.ERROR);
+    }
+
+    @Test
+    @DisplayName("--sum-of-date 22.02.2022 gibt ERROR zurück")
+    void readCLI12() throws IOException {
+        CLIStatus cliStatus = timeTrackerCLI.readCLI(new String[]{"--sum-of-date", "22.02.2022"});
+        assertThat(cliStatus).isEqualTo(CLIStatus.ERROR);
+    }
+
+    @Test
+    @DisplayName("--add 22.02.2022 gibt ERROR zurück")
+    void readCLI13() throws IOException {
+        String[] arguments = {
+                "--add",
+                "22.02.2022,90,ProPra1,\"Stream #4\""
+        };
+        CLIStatus cliStatus = timeTrackerCLI.readCLI(arguments);
+        assertThat(cliStatus).isEqualTo(CLIStatus.ERROR);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ich überprüfe mit einer Regex ob das eingegebene Datum auch 1. ein Datum ist und 2. das gültige Format besitzt. Mit einer anderen Regex wird überprüft, ob auch nur Zahlen als <minuten> Argument bei --add übergeben werden. 
Bei falscher Eingabe wird dies "Ungültige Eingabe" in die Konsole geschrieben und der ERROR Status zurückgegeben, sodass kein Event mit falschen Daten erstellt wird.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Wie beschrieben in #35 .


## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.